### PR TITLE
Update network-services.conf

### DIFF
--- a/itl/plugins-contrib.d/network-services.conf
+++ b/itl/plugins-contrib.d/network-services.conf
@@ -113,6 +113,10 @@ object CheckCommand "fail2ban" {
 			set_if = "$fail2ban_perfdata$"
 			description = "If set to true, activate the perfdata output"
 		}
+		"-j" = {
+			value = "$f2b_jail$"
+			description = "Specify the name of the specific jail to monitor; default is to omit and thus monitor all jails"
+		}
 	}
 
 	vars.fail2ban_perfdata = true


### PR DESCRIPTION
Add option to monitor specific jail only, instead of all. This option has been supported by the check_fail2ban command which comes with fail2ban for years now, but seems to have never found its way to this checkcommand.